### PR TITLE
Resize project find button

### DIFF
--- a/lib/project-find-view.coffee
+++ b/lib/project-find-view.coffee
@@ -35,7 +35,7 @@ class ProjectFindView extends View
       buffer: pathsBuffer
       placeholderText: 'File/directory pattern. eg. `src` to search in the "src" directory or `*.js` to search all javascript files.'
 
-    @div tabIndex: -1, class: 'find-and-replace', =>
+    @div tabIndex: -1, class: 'project-find padded', =>
       @header class: 'header', =>
         @span outlet: 'descriptionLabel', class: 'header-item description'
         @span class: 'header-item options-label pull-right', =>

--- a/styles/find-and-replace.less
+++ b/styles/find-and-replace.less
@@ -171,13 +171,17 @@ atom-workspace.find-visible {
 // Project find and replace
 .project-find {
   @project-input-width: 260px;
-  @project-button-width: 120px;
+  @project-block-width: 220px;
 
   .input-block-item {
-    flex: 1 1 @project-button-width;
+    flex: 1 1 @project-block-width;
   }
   .input-block-item--flex {
     flex: 100 1 @project-input-width;
+  }
+
+  .btn-group-find {
+    flex: .6;
   }
 
   .loading,
@@ -185,14 +189,6 @@ atom-workspace.find-visible {
   .error-messages,
   .filter-container {
     display: none;
-  }
-
-  .btn-group-options {
-    width: @project-button-width;
-  }
-
-  .btn-group-replace-all {
-    width: @project-button-width;
   }
 }
 


### PR DESCRIPTION
This PR is on top of #509. It..
- changes the class back to `project-find`
- resizes the buttons

Note: it will look wrong in the One themes, but that's because they use a custom font-sizes. And should be fixed there. Without a theme it looks correct:

![screen shot 2015-08-27 at 11 14 37 pm](https://cloud.githubusercontent.com/assets/378023/9522772/6a8f32de-4d11-11e5-83a9-e2dd7a099e09.png)
